### PR TITLE
Upgrade workflows to Java 11 and verify plugin for ideaIC 2020.3, 2021.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: zulu
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources
@@ -83,11 +84,12 @@ jobs:
       artifact: ${{ steps.properties.outputs.artifact }}
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: zulu
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,8 @@ jobs:
             ideaIC:2019.3
             ideaIC:2020.1
             ideaIC:2020.2
+            ideaIC:2020.3
+            ideaIC:2021.1
 
       # Print the output of the verify step
       - name: Print Logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: zulu
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources
@@ -39,11 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: zulu
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources


### PR DESCRIPTION
Upgrade workflows to Java 11
Also upgrade to https://github.com/actions/setup-java v2. Using Zulu OpenJDK (default from v1) instead of Adopt OpenJDK.

Add ideaIC 2020.3 and 2021.1 to verify plugin step.